### PR TITLE
Ajout de la carte des Traces de Randos Hivernales

### DIFF
--- a/IGN-trace-rando-hivernale.txt
+++ b/IGN-trace-rando-hivernale.txt
@@ -1,0 +1,10 @@
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+CREATE TABLE IF NOT EXISTS "tiles" ("x" INTEGER NOT NULL, "y" INTEGER NOT NULL, "z" INTEGER NOT NULL, "s" INTEGER, "image" BLOB, "time" INTEGER, PRIMARY KEY ("x", "y", "z"));
+CREATE TABLE IF NOT EXISTS "info" ("useragent" TEXT, "minzoom" TEXT, "maxzoom" TEXT, "url" TEXT, "randoms" TEXT, "referer" TEXT, "ellipsoid" INTEGER, "inverted_y" INTEGER, "tilesize" TEXT, "timeSupported" TEXT, "timecolumn" TEXT, "expireminutes" TEXT, "tilenumbering" TEXT);
+INSERT INTO info VALUES('OsmAnd Maps CFNetwork','6','16','https://wxs.ign.fr/cartovecto/geoportail/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=TRACERANDOHIVERNALE&STYLE=nolegend&TILEMATRIXSET=PM&TILEMATRIX={0}&TILEROW={2}&TILECOL={1}&FORMAT=image/png','','',0,0,'256','yes','yes','43200','simple');
+CREATE INDEX "index_tiles_on_x" ON "tiles" ("x");
+CREATE INDEX "index_tiles_on_y" ON "tiles" ("y");
+CREATE INDEX "index_tiles_on_z" ON "tiles" ("z");
+CREATE INDEX "index_tiles_on_s" ON "tiles" ("s");
+COMMIT;

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,4 @@ all:
 	sqlite3 "IGN BD Ortho.sqlitedb" < IGN-bdortho.txt
 	sqlite3 "IGN Orthophotos 1950-1965.sqlitedb" < IGN-orthophotos-1950-1965.txt
 	sqlite3 "IGN Scan OACI.sqlitedb" < IGN-scan-oaci.txt 
+	sqlite3 "IGN Traces Randos Hivernales.sqlitedb" < IGN-trace-rando-hivernale.txt


### PR DESCRIPTION
en Novembre-Décembre 2023 l'IGN a rendu public la carte des traces de randos hivernales (traits bleus sur une cate TOP25) au protocole WMTS ainsi que WMS vecteur.

[](https://geoservices.ign.fr/actualites/2023-11-01-mises-a-jour)
[](https://geoservices.ign.fr/services-web-experts-cartovecto)
utilisation de la clé partagée "cartovecto" et non pas "altimetrie".
À l'avenir proche il faudra peut-être basculer toutes les urls de type :
https://wxs.ign.fr/cartovecto/geoportail/wmts?SERVICE=WMTS
par :
https://data.geopf.fr/wmts?SERVICE=WMTS

J'ai créé le fichier correspondant et mis à jour le make file.
J'ai testé l'url sur mon OSMAND et ça fonctionne, mais je n'ai pas retesté TOUTE une nouvelle installation à partir du makefile.

doc IGN : https://geoservices.ign.fr/services-web-experts-cartovecto


